### PR TITLE
Fix memory recall edge case

### DIFF
--- a/src/adam/memory.py
+++ b/src/adam/memory.py
@@ -374,7 +374,7 @@ class ADAMMemoryAdvanced:
             n_results=n_results * 2  # Get more candidates for filtering
         )
         
-        if not results['documents'][0]:
+        if not results['documents'] or not results['documents'][0]:
             self.access_patterns["memory_misses"] += 1
             self._save_metadata()
             return []


### PR DESCRIPTION
## Summary
- avoid index errors when recall search yields no documents

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain')*

------
https://chatgpt.com/codex/tasks/task_e_6856cfb3912c832ebe5add4f3e07ca24