### PR TITLE
Add auto-save to memory network and persistence test

### DIFF
--- a/src/adam/memory_network.py
+++ b/src/adam/memory_network.py
@@ -135,25 +135,32 @@ class MemoryNetworkSystem:
         # Load any previously saved network
         self._load_network()
     
-    def add_memory_with_references(self, 
-                                  query: str, 
+    def add_memory_with_references(self,
+                                  query: str,
                                   response: str,
                                   memory_type: str,
                                   topics: List[str],
-                                  potential_references: Optional[List[str]] = None) -> str:
+                                  potential_references: Optional[List[str]] = None,
+                                  *,
+                                  auto_save: bool = True) -> str:
         """
-        Add a new memory and automatically find and link related memories
+        Add a new memory and automatically find and link related memories.
 
         This is like adding a new research paper that cites previous work -
-        we need to find what existing knowledge this builds upon.
+        we need to find what existing knowledge this builds upon.  After the
+        new memory is inserted into the network, the current state of the
+        network is automatically persisted to disk so it is available on the
+        next load.  The auto-save behavior can be disabled when performing
+        bulk updates by passing ``auto_save=False``.
 
         Args:
             query: The question/problem
             response: ADAM's answer/solution
             memory_type: Classification (error_solution, explanation, etc.)
             topics: List of topics this memory covers
-            potential_references: Optional list of memory IDS to reference
-                                  If None, we'll find them automatically
+            potential_references: Optional list of memory IDs to reference.
+                                  If ``None``, we'll find them automatically.
+            auto_save: Persist the network to disk after adding the memory.
 
         Returns:
             memory_id: The ID of the newly created memory
@@ -219,7 +226,10 @@ class MemoryNetworkSystem:
         
         # Update or the conversation thread for this topic
         self._update_conversation_thread(memory_node)
-        
+
+        if auto_save:
+            self._save_network()
+
         return memory_id
     
     def _find_related_memories(self, query: str, topics: List[str], 

--- a/tests/test_memory_network_persistence.py
+++ b/tests/test_memory_network_persistence.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+from src.adam.memory_network import MemoryNetworkSystem
+
+class DummyBaseMemory:
+    def __init__(self):
+        self.counter = 0
+
+    def remember_if_worthy(self, query: str, response: str, generation_cost=0.0, model_used="test"):
+        self.counter += 1
+        return f"mem_{self.counter}"
+
+class DummyConversationSystem:
+    class Session:
+        def __init__(self, session_id: str):
+            self.session_id = session_id
+
+    def __init__(self):
+        self.current_session = self.Session("session_1")
+
+def test_memory_persists_across_reload(tmp_path, monkeypatch):
+    """Newly added memories should be available after reloading the network."""
+    monkeypatch.chdir(tmp_path)
+
+    base = DummyBaseMemory()
+    conv = DummyConversationSystem()
+
+    net = MemoryNetworkSystem(base, conv)
+    mem_id = net.add_memory_with_references(
+        query="q1",
+        response="r1",
+        memory_type="test",
+        topics=["topic"],
+    )
+
+    graph_file = tmp_path / "adam_memory_advanced" / "memory_network" / "memory_graph.gpickle"
+    assert graph_file.exists()
+
+    # Reload from disk and verify the memory is present
+    net2 = MemoryNetworkSystem(base, conv)
+    assert mem_id in net2.memory_graph.nodes


### PR DESCRIPTION
## Summary
- add `auto_save` support to `add_memory_with_references`
- persist network after adding new memory
- test that new memories survive reloads

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_6859922c3cf8832e8697c050f11396d1